### PR TITLE
Add PM discovery metadata store and workspace-safe naming

### DIFF
--- a/proyecto/PM_microservice/discoverer_threaded.py
+++ b/proyecto/PM_microservice/discoverer_threaded.py
@@ -12,6 +12,12 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS
 import traceback
 from pm4py.visualization.powl.variants import net
+from metadata_store import (
+    init_metadata_db,
+    insert_discovery_metadata,
+    name_exists,
+    update_discovery_status,
+)
 
 app = Flask(__name__)
 CORS(app)
@@ -20,8 +26,27 @@ CORS(app)
 for folder in ['./imports', './imports2', './reference', './dfg', './bpmn', './pnml', './ptml']:
     os.makedirs(folder, exist_ok=True)
 
+init_metadata_db()
 
-def run_discovery(file_path, file_uuid, mode):
+
+def normalize_mode(mode):
+    return "reference" if mode == "1" else "log"
+
+
+def resolve_display_name(discovery_id, workspace_uuid, mode, requested_name):
+    default_name = requested_name.strip() if requested_name and requested_name.strip() else discovery_id
+    if not name_exists(workspace_uuid, mode, default_name):
+        return default_name
+
+    shortid = discovery_id[:8]
+    fallback_name = f"{shortid}+{default_name}"
+    while name_exists(workspace_uuid, mode, fallback_name):
+        shortid = str(uuid.uuid4())[:8]
+        fallback_name = f"{shortid}+{default_name}"
+    return fallback_name
+
+
+def run_discovery(file_path, discovery_id, mode):
     try:
         dtype_spec = {
             "Curricular Unit": str,
@@ -44,7 +69,7 @@ def run_discovery(file_path, file_uuid, mode):
         )
 
         # Save initial XES
-        pm4py.write_xes(event_log, f'./imports/{file_uuid}.xes')
+        pm4py.write_xes(event_log, f'./imports/{discovery_id}.xes')
 
         # Update activity names for certain cases
         event_log['Activity'] = event_log.apply(
@@ -63,61 +88,63 @@ def run_discovery(file_path, file_uuid, mode):
 
         # Save updated XES
         if mode == "1":
-            pm4py.write_xes(event_log, f'./reference/{file_uuid}.xes')
+            pm4py.write_xes(event_log, f'./reference/{discovery_id}.xes')
         else:
-            pm4py.write_xes(event_log, f'./imports2/{file_uuid}.xes')
+            pm4py.write_xes(event_log, f'./imports2/{discovery_id}.xes')
             
         # --- DFG ---
         dfg, dfg_start_activities, dfg_end_activities = pm4py.discover_dfg(event_log)
-        pm4py.write_dfg(dfg, dfg_start_activities, dfg_end_activities, f'./dfg/{file_uuid}.dfg')
+        pm4py.write_dfg(dfg, dfg_start_activities, dfg_end_activities, f'./dfg/{discovery_id}.dfg')
         del dfg
         del dfg_start_activities
         del dfg_end_activities
         
-        print(f"[{file_uuid}] Discovery DFG completed successfully.")
+        print(f"[{discovery_id}] Discovery DFG completed successfully.")
 
         # --- PNML ---
         net, im, fm = pm4py.discover_petri_net_alpha(event_log)
-        pm4py.write_pnml(net, im, fm, f'./pnml/{file_uuid}_alpha.pnml')
+        pm4py.write_pnml(net, im, fm, f'./pnml/{discovery_id}_alpha.pnml')
         del net
         del im
         del fm
-        print(f"[{file_uuid}] Discovery PNML with Alpha completed successfully.")
+        print(f"[{discovery_id}] Discovery PNML with Alpha completed successfully.")
         net2, im2, fm2 = pm4py.discover_petri_net_heuristics(event_log)
-        pm4py.write_pnml(net2, im2, fm2, f'./pnml/{file_uuid}_heuristics.pnml')
+        pm4py.write_pnml(net2, im2, fm2, f'./pnml/{discovery_id}_heuristics.pnml')
         del net2
         del im2
         del fm2
-        print(f"[{file_uuid}] Discovery PNML with Heuristics completed successfully.")
+        print(f"[{discovery_id}] Discovery PNML with Heuristics completed successfully.")
         net3, im3, fm3 = pm4py.discover_petri_net_inductive(event_log) #takes longer, goes last
-        pm4py.write_pnml(net3, im3, fm3, './pnml/' + file_uuid + '_inductive.pnml')
-        print(f"[{file_uuid}] Discovery PNML with Inductive completed successfully.")
+        pm4py.write_pnml(net3, im3, fm3, './pnml/' + discovery_id + '_inductive.pnml')
+        print(f"[{discovery_id}] Discovery PNML with Inductive completed successfully.")
         
-        print(f"[{file_uuid}] Discovery PNML completed successfully.")
+        print(f"[{discovery_id}] Discovery PNML completed successfully.")
         
         # --- BPMN --- Removed, takes too much time
         bpmn_graph = pm4py.convert_to_bpmn(net3, im3, fm3)
-        pm4py.write_bpmn(bpmn_graph, f'./bpmn/{file_uuid}.bpmn', auto_layout=False)
+        pm4py.write_bpmn(bpmn_graph, f'./bpmn/{discovery_id}.bpmn', auto_layout=False)
         del bpmn_graph
         
-        print(f"[{file_uuid}] Discovery BPMN completed successfully.")
+        print(f"[{discovery_id}] Discovery BPMN completed successfully.")
         
 
         # --- PTML --- Removed, takes too much time
         process_tree = pm4py.convert_to_process_tree(net3, im3, fm3)
-        pm4py.write_ptml(process_tree, f'./ptml/{file_uuid}.ptml', auto_layout=True)
+        pm4py.write_ptml(process_tree, f'./ptml/{discovery_id}.ptml', auto_layout=True)
         del process_tree
         
-        print(f"[{file_uuid}] Discovery PTML completed successfully.")
+        print(f"[{discovery_id}] Discovery PTML completed successfully.")
         
         del net3
         del im3
         del fm3
 
-        print(f"[{file_uuid}] Discovery completed successfully.")
+        update_discovery_status(discovery_id, "completed")
+        print(f"[{discovery_id}] Discovery completed successfully.")
 
     except Exception as e:
-        print(f"[{file_uuid}] ERROR during discovery: {e}")
+        update_discovery_status(discovery_id, "failed")
+        print(f"[{discovery_id}] ERROR during discovery: {e}")
         traceback.print_exc()
 
 @app.route('/', methods=['POST'])
@@ -125,22 +152,38 @@ def run_discovery(file_path, file_uuid, mode):
 def discover(mode):
     if 'file' not in request.files:
         return jsonify({'error': 'No file'}), 400
+    workspace_uuid = request.form.get('workspace_uuid')
+    if not workspace_uuid:
+        return jsonify({'error': 'Missing workspace_uuid'}), 400
 
     file = request.files['file']
-    file_uuid = str(uuid.uuid4())
+    discovery_id = str(uuid.uuid4())
+    mode_label = normalize_mode(mode)
+    requested_name = request.form.get('name')
+    display_name = resolve_display_name(discovery_id, workspace_uuid, mode_label, requested_name)
 
     try:
         # Save uploaded CSV to disk so thread can access it
-        file_path = f'./imports/{file_uuid}.csv'
+        file_path = f'./imports/{discovery_id}.csv'
         file.save(file_path)
 
+        insert_discovery_metadata(
+            discovery_id=discovery_id,
+            workspace_uuid=workspace_uuid,
+            mode=mode_label,
+            display_name=display_name,
+            original_name=requested_name,
+            status="started",
+        )
+
         # Start discovery in background thread
-        thread = threading.Thread(target=run_discovery, args=(file_path, file_uuid, mode))
+        thread = threading.Thread(target=run_discovery, args=(file_path, discovery_id, mode))
         thread.start()
 
         # Respond immediately with job ID
         return jsonify({
-            'uuid': file_uuid,
+            'discovery_id': discovery_id,
+            'display_name': display_name,
             'status': 'started'
         })
 

--- a/proyecto/PM_microservice/metadata_store.py
+++ b/proyecto/PM_microservice/metadata_store.py
@@ -1,0 +1,124 @@
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+BASE_DIR = Path(__file__).resolve().parent
+DB_PATH = BASE_DIR / "pm_metadata.db"
+
+_DB_LOCK = threading.Lock()
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def init_metadata_db() -> None:
+    with _DB_LOCK:
+        conn = sqlite3.connect(DB_PATH)
+        try:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS discovery_metadata (
+                    discovery_id TEXT PRIMARY KEY,
+                    workspace_uuid TEXT NOT NULL,
+                    mode TEXT NOT NULL,
+                    display_name TEXT NOT NULL,
+                    original_name TEXT,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    completed_at TEXT
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_discovery_workspace_mode_name
+                ON discovery_metadata(workspace_uuid, mode, display_name)
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def name_exists(workspace_uuid: str, mode: str, display_name: str) -> bool:
+    with _DB_LOCK:
+        conn = sqlite3.connect(DB_PATH)
+        try:
+            row = conn.execute(
+                """
+                SELECT 1
+                FROM discovery_metadata
+                WHERE workspace_uuid = ? AND mode = ? AND display_name = ?
+                LIMIT 1
+                """,
+                (workspace_uuid, mode, display_name),
+            ).fetchone()
+            return row is not None
+        finally:
+            conn.close()
+
+
+def insert_discovery_metadata(
+    discovery_id: str,
+    workspace_uuid: str,
+    mode: str,
+    display_name: str,
+    original_name: str | None,
+    status: str = "started",
+) -> None:
+    now_iso = _utc_now_iso()
+    with _DB_LOCK:
+        conn = sqlite3.connect(DB_PATH)
+        try:
+            conn.execute(
+                """
+                INSERT INTO discovery_metadata (
+                    discovery_id,
+                    workspace_uuid,
+                    mode,
+                    display_name,
+                    original_name,
+                    status,
+                    created_at,
+                    updated_at,
+                    completed_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                """,
+                (
+                    discovery_id,
+                    workspace_uuid,
+                    mode,
+                    display_name,
+                    original_name,
+                    status,
+                    now_iso,
+                    now_iso,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def update_discovery_status(discovery_id: str, status: str) -> None:
+    now_iso = _utc_now_iso()
+    completed_at = now_iso if status in {"completed", "failed"} else None
+    with _DB_LOCK:
+        conn = sqlite3.connect(DB_PATH)
+        try:
+            conn.execute(
+                """
+                UPDATE discovery_metadata
+                SET status = ?, updated_at = ?, completed_at = ?
+                WHERE discovery_id = ?
+                """,
+                (status, now_iso, completed_at, discovery_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()


### PR DESCRIPTION
### Motivation
- Provide persistent metadata for PM discovery jobs including workspace-scoped identity, status and timestamps so discoveries can be looked up and managed.  
- Prevent filesystem collisions by keeping artifact filenames keyed to an immutable `discovery_id` while allowing human-friendly names per workspace+mode.  
- Ensure API clients can request a `name` and receive a deterministic `display_name` even when duplicates exist within the same workspace and mode.

### Description
- Add `proyecto/PM_microservice/metadata_store.py` which creates a SQLite DB (`pm_metadata.db`) and provides `init_metadata_db`, `insert_discovery_metadata`, `name_exists`, and `update_discovery_status` helpers and an index for workspace+mode+display_name.  
- Initialize the metadata DB on service startup in `discoverer_threaded.py` and normalize route `mode` into metadata values `reference`/`log`.  
- Require `workspace_uuid` in the discovery request and accept an optional `name`, resolving collisions per workspace+mode by generating a fallback of the form `<shortid>+<name>` when needed.  
- Persist metadata with status `started` before launching the background thread, update the record to `completed` or `failed` when the worker finishes, and keep all artifact filenames keyed by the immutable `discovery_id`.  
- Update the discovery API response to return both `discovery_id` and the resolved `display_name` (plus `status`).

### Testing
- Ran `python -m py_compile proyecto/PM_microservice/discoverer_threaded.py proyecto/PM_microservice/metadata_store.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d45330b990833284ad58a2c93eb1b6)