### PR TITLE
Require workspace-scoped discovery access; add metadata lookup and path resolution

### DIFF
--- a/proyecto/PM_microservice/CU_stats.py
+++ b/proyecto/PM_microservice/CU_stats.py
@@ -5,13 +5,12 @@ Created on 23 jul. 2025
 '''
 import pm4py
 import os
-import uuid
-import pandas as pd
-from flask import Flask, request, jsonify, send_file
+from flask import Flask, request, jsonify
 from collections import Counter, defaultdict
 from flask_cors import CORS
 
 import traceback #for debugging
+from discovery_access import validate_workspace_access
 
 app = Flask(__name__)
 CORS(app) #Without cors it gets blocked
@@ -19,7 +18,15 @@ CORS(app) #Without cors it gets blocked
 @app.route('/<caseid>/<cu>', methods=['GET'])
 def stats(caseid, cu):
     try:
-        filepath = './imports/' + caseid + '.xes'
+        workspace_uuid = request.args.get('workspace_uuid')
+        if not workspace_uuid:
+            return jsonify({'error': 'Missing workspace_uuid'}), 400
+
+        metadata, error_response = validate_workspace_access(caseid, workspace_uuid)
+        if error_response:
+            return error_response
+
+        filepath = './imports/' + metadata['discovery_id'] + '.xes'
         if os.path.exists(filepath):
             event_log = pm4py.read_xes(filepath)
             event_log = pm4py.format_dataframe(event_log, case_id="ID", activity_key="Activity", timestamp_key="Timestamp", timest_format='%a %b %d %H:%M:%S %Z %Y')

--- a/proyecto/PM_microservice/Discover_stats.py
+++ b/proyecto/PM_microservice/Discover_stats.py
@@ -4,13 +4,11 @@ Created on 22 ago. 2025
 @author: sndc3
 '''
 import pm4py
-import os
-import uuid
-import pandas as pd
-from flask import Flask, request, jsonify, send_file
+from flask import Flask, request, jsonify
 from flask_cors import CORS
 
 import traceback #for debugging
+from discovery_access import resolve_discovery_xes_path, validate_workspace_access
 
 app = Flask(__name__)
 CORS(app)
@@ -18,40 +16,45 @@ CORS(app)
 @app.route('/<mode>/<caseid>', methods=['GET'])
 def stats(mode, caseid):
     try:
-        if mode == "1":
-            filepath = './reference/' + caseid + '.xes'
-        else:
-            filepath = './imports2/' + caseid + '.xes'
-        if os.path.exists(filepath):
-            event_log = pm4py.read_xes(filepath)
-            event_log = pm4py.format_dataframe(event_log, case_id="ID", activity_key="Activity", timestamp_key="Timestamp", timest_format='%a %b %d %H:%M:%S %Z %Y')
-            event_log = pm4py.convert_to_event_log(event_log)
-            
-            variants = pm4py.stats.get_variants(event_log)
-            num_variants = len(variants)
-            num_traces = len(event_log)
-            
-            start_activities = pm4py.stats.get_start_activities(event_log)
-            end_activities = pm4py.stats.get_end_activities(event_log)
-            
-            all_activities = list(pm4py.stats.get_event_attribute_values(event_log, "Activity").keys())
-            
-            result = {
-                "num_variants": num_variants,
-                "num_traces": num_traces,
-                "start_activities": start_activities,
-                "end_activities": end_activities,
-                "all_activities": all_activities
-            }
+        workspace_uuid = request.args.get('workspace_uuid')
+        if not workspace_uuid:
+            return jsonify({'error': 'Missing workspace_uuid'}), 400
 
-            return jsonify(result)
-            
-        else:
-            return "Unknown case id"
-        
+        allowed_modes = {'1': {'reference'}, '2': {'log'}}
+        metadata, error_response = validate_workspace_access(caseid, workspace_uuid, allowed_modes.get(mode))
+        if error_response:
+            return error_response
+
+        filepath = resolve_discovery_xes_path(metadata)
+        if not filepath:
+            return jsonify({'error': 'Unknown discovery id'}), 404
+
+        event_log = pm4py.read_xes(filepath)
+        event_log = pm4py.format_dataframe(event_log, case_id="ID", activity_key="Activity", timestamp_key="Timestamp", timest_format='%a %b %d %H:%M:%S %Z %Y')
+        event_log = pm4py.convert_to_event_log(event_log)
+
+        variants = pm4py.stats.get_variants(event_log)
+        num_variants = len(variants)
+        num_traces = len(event_log)
+
+        start_activities = pm4py.stats.get_start_activities(event_log)
+        end_activities = pm4py.stats.get_end_activities(event_log)
+
+        all_activities = list(pm4py.stats.get_event_attribute_values(event_log, "Activity").keys())
+
+        result = {
+            "num_variants": num_variants,
+            "num_traces": num_traces,
+            "start_activities": start_activities,
+            "end_activities": end_activities,
+            "all_activities": all_activities
+        }
+
+        return jsonify(result)
+
     except Exception as e:
         tb = traceback.format_exc()
         return jsonify({'error': str(e), 'trace': tb}), 500
-    
+
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0', port=9009)

--- a/proyecto/PM_microservice/Plan_stats.py
+++ b/proyecto/PM_microservice/Plan_stats.py
@@ -5,14 +5,13 @@ Created on 10 ago. 2025
 '''
 import pm4py
 import os
-import uuid
-import pandas as pd
 import json
-from flask import Flask, request, jsonify, send_file
+from flask import Flask, request, jsonify
 from collections import Counter, defaultdict
 from flask_cors import CORS
 
 import traceback #for debugging
+from discovery_access import validate_workspace_access
 
 app = Flask(__name__)
 CORS(app) #Without cors it gets blocked
@@ -24,7 +23,15 @@ for folder in ['./stats']:
 @app.route('/<caseid>/<career>/<plan>', methods=['GET'])
 def stats(caseid, career, plan):
     try:
-        filepath = './imports/' + caseid + '.xes'
+        workspace_uuid = request.args.get('workspace_uuid')
+        if not workspace_uuid:
+            return jsonify({'error': 'Missing workspace_uuid'}), 400
+
+        metadata, error_response = validate_workspace_access(caseid, workspace_uuid)
+        if error_response:
+            return error_response
+
+        filepath = './imports/' + metadata['discovery_id'] + '.xes'
         if os.path.exists(filepath):
             filepath2 = './stats/' + caseid + '_plan.json'
             if os.path.exists(filepath2):

--- a/proyecto/PM_microservice/alignement_viewer.py
+++ b/proyecto/PM_microservice/alignement_viewer.py
@@ -5,13 +5,12 @@ Created on 19 ago. 2025
 '''
 import pm4py
 import os
-import uuid
-import pandas as pd
 import threading
 from flask import Flask, request, jsonify, send_file
 from flask_cors import CORS
 
 import traceback #for debugging
+from discovery_access import resolve_discovery_xes_path, validate_workspace_access
 
 app = Flask(__name__)
 CORS(app) #Without cors it gets blocked
@@ -19,59 +18,75 @@ CORS(app) #Without cors it gets blocked
 # Create required folders if doesnt exists
 for folder in ['./conformance']:
     os.makedirs(folder, exist_ok=True)
-    
+
 render_status = {}
-    
-def run_viewer(mode, reference, caseid):
+
+
+def run_viewer(mode, reference, caseid, workspace_uuid):
     try:
-        render_status[(reference, caseid, mode)] = "rendering"   
+        render_status[(reference, caseid, mode)] = "rendering"
+        metadata, error_response = validate_workspace_access(caseid, workspace_uuid, {'log'})
+        if error_response:
+            return
+
         pnfilepath = './pnml/' + reference + '_' + mode + '.pnml'
-        elfilepath = './imports2/' + caseid + '.xes'
+        elfilepath = resolve_discovery_xes_path(metadata)
         imagepath = './conformance/' + reference + '/alignements/' + caseid + '_' + mode + '.svg'
-        
+
         if not os.path.exists(pnfilepath):
-            return "Unknown reference id"
-        if not os.path.exists(elfilepath):
-            return "Unknown discovery id"
-        
+            return
+        if not elfilepath or not os.path.exists(elfilepath):
+            return
+
         os.makedirs('./conformance/' + reference + '/alignements', exist_ok=True)
-        
+
         event_log = pm4py.read_xes(elfilepath)
         net, im, fm = pm4py.read_pnml(pnfilepath)
-        
+
         conformance_alignment = pm4py.conformance.conformance_diagnostics_alignments(event_log, net, im, fm)
         pm4py.save_vis_alignments(event_log, conformance_alignment, imagepath)
-        
+
         render_status[(reference, caseid, mode)] = "completed"
     except Exception as e:
         tb = traceback.format_exc()
         return jsonify({'error': str(e), 'trace': tb}), 500
-    
+
+
 @app.route('/<mode>/<reference>/<caseid>', methods=['GET'])
 def TBR(mode, reference, caseid):
     try:
         # If rendering is ongoing, report status
         if render_status.get((reference, caseid, mode)) == "rendering":
             return jsonify({'status': 'rendering'}), 202
+
+        workspace_uuid = request.args.get('workspace_uuid')
+        if not workspace_uuid:
+            return jsonify({'error': 'Missing workspace_uuid'}), 400
+
+        metadata, error_response = validate_workspace_access(caseid, workspace_uuid, {'log'})
+        if error_response:
+            return error_response
+
         pnfilepath = './pnml/' + reference + '_' + mode + '.pnml'
-        elfilepath = './imports2/' + caseid + '.xes'
+        elfilepath = resolve_discovery_xes_path(metadata)
         imagepath = './conformance/' + reference + '/alignements/' + caseid + '_' + mode + '.svg'
-        
+
         if not os.path.exists(pnfilepath):
-            return "Unknown reference id"
-        if not os.path.exists(elfilepath):
-            return "Unknown discovery id"
-        
+            return jsonify({'error': 'Unknown reference id'}), 404
+        if not elfilepath or not os.path.exists(elfilepath):
+            return jsonify({'error': 'Unknown discovery id'}), 404
+
         if os.path.exists(imagepath):
-                    return send_file(imagepath, mimetype='image/svg+xml')
-        
-        thread = threading.Thread(target=run_viewer, args=(mode, reference, caseid))
+            return send_file(imagepath, mimetype='image/svg+xml')
+
+        thread = threading.Thread(target=run_viewer, args=(mode, reference, caseid, workspace_uuid))
         thread.start()
         return jsonify({'status': 'rendering started'}), 200
-        
+
     except Exception as e:
         tb = traceback.format_exc()
         return jsonify({'error': str(e), 'trace': tb}), 500
-    
+
+
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0', port=9008)

--- a/proyecto/PM_microservice/basic_stats.py
+++ b/proyecto/PM_microservice/basic_stats.py
@@ -4,57 +4,57 @@ Created on 10 jul. 2025
 @author: Santiago Nicolas Diaz Conde
 '''
 import pm4py
-import os
-import uuid
-import pandas as pd
-from flask import Flask, request, jsonify, send_file
+from flask import Flask, request, jsonify
 from flask_cors import CORS
 
 import traceback #for debugging
+from discovery_access import resolve_discovery_xes_path, validate_workspace_access
 
 app = Flask(__name__)
 CORS(app)
 
 @app.route('/<caseid>', methods=['GET'])
 @app.route('/<caseid>/<mode>', methods=['GET'])
-def stats(caseid, mode):
+def stats(caseid, mode='2'):
     try:
-        if mode == 1:
-            filepath = './reference/' + caseid + '.xes'
-        else:
-            if mode == 2:
-                filepath = './imports2/' + caseid + '.xes'
-            else:
-                filepath = './imports/' + caseid + '.xes'
-        if os.path.exists(filepath):
-            event_log = pm4py.read_xes(filepath)
-            event_log = pm4py.format_dataframe(event_log, case_id="ID", activity_key="Activity", timestamp_key="Timestamp", timest_format='%a %b %d %H:%M:%S %Z %Y')
-            event_log = pm4py.convert_to_event_log(event_log)
-            
-            #From XES
-            num_cases = len(set(trace.attributes["concept:name"] for trace in event_log))
-            num_events = sum(len(trace) for trace in event_log)
-            num_variants = len(pm4py.get_variants(event_log))
-            start_activities = pm4py.get_start_activities(event_log)
-            end_activities = pm4py.get_end_activities(event_log)
-            start_activities_dict = dict(start_activities)
-            end_activities_dict = dict(end_activities)
-            
-            return jsonify({
-                'uuid': caseid,
-                'cases': num_cases,
-                'events': num_events,
-                'variants': num_variants,
-                "start_activities": start_activities_dict,
-                "end_activities": end_activities_dict
-            })            
-            
-        else:
-            return "Unknown id"
-        
+        workspace_uuid = request.args.get('workspace_uuid')
+        if not workspace_uuid:
+            return jsonify({'error': 'Missing workspace_uuid'}), 400
+
+        allowed_modes = {'1': {'reference'}, '2': {'log'}}
+        metadata, error_response = validate_workspace_access(caseid, workspace_uuid, allowed_modes.get(mode))
+        if error_response:
+            return error_response
+
+        filepath = resolve_discovery_xes_path(metadata)
+        if not filepath:
+            return jsonify({'error': 'Unknown discovery id'}), 404
+
+        event_log = pm4py.read_xes(filepath)
+        event_log = pm4py.format_dataframe(event_log, case_id="ID", activity_key="Activity", timestamp_key="Timestamp", timest_format='%a %b %d %H:%M:%S %Z %Y')
+        event_log = pm4py.convert_to_event_log(event_log)
+
+        #From XES
+        num_cases = len(set(trace.attributes["concept:name"] for trace in event_log))
+        num_events = sum(len(trace) for trace in event_log)
+        num_variants = len(pm4py.get_variants(event_log))
+        start_activities = pm4py.get_start_activities(event_log)
+        end_activities = pm4py.get_end_activities(event_log)
+        start_activities_dict = dict(start_activities)
+        end_activities_dict = dict(end_activities)
+
+        return jsonify({
+            'uuid': caseid,
+            'cases': num_cases,
+            'events': num_events,
+            'variants': num_variants,
+            "start_activities": start_activities_dict,
+            "end_activities": end_activities_dict
+        })
+
     except Exception as e:
         tb = traceback.format_exc()
         return jsonify({'error': str(e), 'trace': tb}), 500
-    
+
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0', port=9002)

--- a/proyecto/PM_microservice/conformanceTest.py
+++ b/proyecto/PM_microservice/conformanceTest.py
@@ -6,12 +6,11 @@ Created on 13 ago. 2025
 import pm4py
 import os
 import json
-import uuid
-import pandas as pd
-from flask import Flask, request, jsonify, send_file
+from flask import Flask, request, jsonify
 from flask_cors import CORS
 
 import traceback #for debugging
+from discovery_access import resolve_discovery_xes_path, validate_workspace_access
 
 app = Flask(__name__)
 CORS(app)
@@ -19,7 +18,8 @@ CORS(app)
 # Create required folders if doesnt exists
 for folder in ['./conformance']:
     os.makedirs(folder, exist_ok=True)
-    
+
+
 def serialize(obj):
     if isinstance(obj, (str, int, float, bool)) or obj is None:
         return obj
@@ -33,49 +33,59 @@ def serialize(obj):
         return obj.name
     return str(obj)
 
+
 @app.route('/<mode>/<reference>/<caseid>', methods=['GET'])
 def TBR(mode, reference, caseid):
     try:
+        workspace_uuid = request.args.get('workspace_uuid')
+        if not workspace_uuid:
+            return jsonify({'error': 'Missing workspace_uuid'}), 400
+
+        metadata, error_response = validate_workspace_access(caseid, workspace_uuid, {'log'})
+        if error_response:
+            return error_response
+
         pnfilepath = './pnml/' + reference + '_' + mode + '.pnml'
-        elfilepath = './imports2/' + caseid + '.xes'
-        
+        elfilepath = resolve_discovery_xes_path(metadata)
+
         if not os.path.exists(pnfilepath):
-            return "Unknown reference id"
-        if not os.path.exists(elfilepath):
-            return "Unknown discovery id"
-        
+            return jsonify({'error': 'Unknown reference id'}), 404
+        if not elfilepath or not os.path.exists(elfilepath):
+            return jsonify({'error': 'Unknown discovery id'}), 404
+
         filepath = './conformance/' + reference + '/' + caseid + '_' + mode + '.json'
-        
+
         if os.path.exists(filepath):
             with open(filepath, "r", encoding="utf-8") as f:
                 data = json.load(f)
             return jsonify(data)
-        
+
         event_log = pm4py.read_xes(elfilepath)
         net, im, fm = pm4py.read_pnml(pnfilepath)
-        
+
         conformance_diagnostics = pm4py.conformance.conformance_diagnostics_token_based_replay(event_log, net, im, fm)
-        
+
         conformance_fitness = pm4py.fitness_token_based_replay(event_log, net, im, fm)
-        
-        conformance_precision = pm4py.precision_token_based_replay(event_log, net, im, fm)        
+
+        conformance_precision = pm4py.precision_token_based_replay(event_log, net, im, fm)
 
         result = {
             "token_based_replay": conformance_diagnostics,
             "fitness": conformance_fitness,
             "precision": conformance_precision
         }
-        
+
         clean_result = serialize(result)
-        
+
         with open(filepath, "w", encoding="utf-8") as f:
             json.dump(clean_result, f, indent=4, ensure_ascii=False)
-        
+
         return jsonify(result)
-    
+
     except Exception as e:
         tb = traceback.format_exc()
         return jsonify({'error': str(e), 'trace': tb}), 500
-    
+
+
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0', port=9007)

--- a/proyecto/PM_microservice/discovery_access.py
+++ b/proyecto/PM_microservice/discovery_access.py
@@ -1,0 +1,34 @@
+import os
+from flask import jsonify
+
+from metadata_store import get_discovery_metadata, init_metadata_db
+
+
+init_metadata_db()
+
+
+MODE_TO_FOLDER = {
+    "reference": "./reference",
+    "log": "./imports2",
+}
+
+
+def validate_workspace_access(discovery_id, workspace_uuid, allowed_modes=None):
+    metadata = get_discovery_metadata(discovery_id)
+    if metadata is None:
+        return None, (jsonify({"error": "Unknown discovery id"}), 404)
+
+    if metadata["workspace_uuid"] != workspace_uuid:
+        return None, (jsonify({"error": "Forbidden discovery access"}), 403)
+
+    if allowed_modes and metadata["mode"] not in allowed_modes:
+        return None, (jsonify({"error": "Unknown discovery id"}), 404)
+
+    return metadata, None
+
+
+def resolve_discovery_xes_path(metadata):
+    folder = MODE_TO_FOLDER.get(metadata["mode"])
+    if folder is None:
+        return None
+    return os.path.join(folder, f"{metadata['discovery_id']}.xes")

--- a/proyecto/PM_microservice/listDiscovers.py
+++ b/proyecto/PM_microservice/listDiscovers.py
@@ -3,30 +3,47 @@ Created on 15 jul. 2025
 
 @author: Santiago Nicolas Diaz Conde
 '''
-from flask import Flask, jsonify
-import os
+from flask import Flask, jsonify, request
 from flask_cors import CORS
+
+from metadata_store import init_metadata_db, list_discoveries
 
 app = Flask(__name__)
 CORS(app) #Without cors it gets blocked
 
+init_metadata_db()
+
+
 @app.route('/', methods=['GET'])
+def list_workspace_discoveries():
+    workspace_uuid = request.args.get('workspace_uuid')
+    if not workspace_uuid:
+        return jsonify({'error': 'Missing workspace_uuid'}), 400
+
+    mode = request.args.get('mode')
+    if mode == '1':
+        mode = 'reference'
+    elif mode == '2':
+        mode = 'log'
+
+    return jsonify(list_discoveries(workspace_uuid, mode))
+
+
 @app.route('/<mode>', methods=['GET'])
-def list_files(mode):
-    if mode == "1":
-        folder_path = './reference' #reference only
+def list_files_deprecated(mode):
+    workspace_uuid = request.args.get('workspace_uuid')
+    if not workspace_uuid:
+        return jsonify({'error': 'Missing workspace_uuid'}), 400
+
+    if mode == '1':
+        normalized_mode = 'reference'
+    elif mode == '2':
+        normalized_mode = 'log'
     else:
-        if mode == "2":
-            folder_path = './imports2' #logs only
-        else:
-            folder_path = './imports' #all
-    try:
-        files = os.listdir(folder_path)
-        # Remove extensions from filenames
-        filenames = [os.path.splitext(f)[0] for f in files if os.path.isfile(os.path.join(folder_path, f))]
-        return jsonify(filenames)
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'Unsupported mode'}), 400
+
+    discoveries = list_discoveries(workspace_uuid, normalized_mode)
+    return jsonify([item['discovery_id'] for item in discoveries])
 
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0', port=9004)

--- a/proyecto/PM_microservice/metadata_store.py
+++ b/proyecto/PM_microservice/metadata_store.py
@@ -122,3 +122,52 @@ def update_discovery_status(discovery_id: str, status: str) -> None:
             conn.commit()
         finally:
             conn.close()
+
+
+def get_discovery_metadata(discovery_id: str) -> dict | None:
+    with _DB_LOCK:
+        conn = sqlite3.connect(DB_PATH)
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                """
+                SELECT discovery_id, workspace_uuid, mode, display_name, status, created_at
+                FROM discovery_metadata
+                WHERE discovery_id = ?
+                LIMIT 1
+                """,
+                (discovery_id,),
+            ).fetchone()
+            return dict(row) if row is not None else None
+        finally:
+            conn.close()
+
+
+def list_discoveries(workspace_uuid: str, mode: str | None = None) -> list[dict]:
+    with _DB_LOCK:
+        conn = sqlite3.connect(DB_PATH)
+        conn.row_factory = sqlite3.Row
+        try:
+            if mode:
+                rows = conn.execute(
+                    """
+                    SELECT discovery_id, display_name, status, created_at
+                    FROM discovery_metadata
+                    WHERE workspace_uuid = ? AND mode = ?
+                    ORDER BY created_at DESC
+                    """,
+                    (workspace_uuid, mode),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    """
+                    SELECT discovery_id, display_name, status, created_at
+                    FROM discovery_metadata
+                    WHERE workspace_uuid = ?
+                    ORDER BY created_at DESC
+                    """,
+                    (workspace_uuid,),
+                ).fetchall()
+            return [dict(row) for row in rows]
+        finally:
+            conn.close()

--- a/proyecto/PM_microservice/viewer_threaded.py
+++ b/proyecto/PM_microservice/viewer_threaded.py
@@ -12,6 +12,7 @@ from flask import Flask, request, jsonify, send_file
 from flask_cors import CORS
 
 import traceback #for debugging
+from discovery_access import resolve_discovery_xes_path, validate_workspace_access
 
 app = Flask(__name__)
 CORS(app) #Without cors it gets blocked
@@ -22,7 +23,7 @@ for folder in ['./imports', './dfg/png', './bpmn/png', './pnml/png', './ptml/png
     
 render_status = {}
 
-def run_viewer(view, caseid, mode, activity, path, filtermode):
+def run_viewer(view, caseid, mode, activity, path, filtermode, metadata_path):
     try:
         render_status[(view, caseid, activity, path)] = "rendering"
         match view:
@@ -141,10 +142,7 @@ def run_viewer(view, caseid, mode, activity, path, filtermode):
 
                 dfg_freq, start_acts_freq, end_acts_freq = pm4py.read_dfg(freq_dfg_file)
                 
-                if mode == "1":
-                    filepathLog = './reference/' + caseid + '.xes'
-                else:
-                    filepathLog = './imports2/' + caseid + '.xes'
+                filepathLog = metadata_path
                 if os.path.exists(filepathLog):
                     event_log = pm4py.read_xes(filepathLog)
                     event_log = pm4py.format_dataframe(event_log, case_id="ID", activity_key="Activity", timestamp_key="Timestamp", timest_format='%a %b %d %H:%M:%S %Z %Y')
@@ -239,6 +237,19 @@ def viewer(view, caseid, mode=0):
         activity = float(request.args.get("activity", 100))
         path = float(request.args.get("path", 100))
         filtermode = int(request.args.get("filtermode", 2))
+
+        workspace_uuid = request.args.get("workspace_uuid")
+        if not workspace_uuid:
+            return jsonify({'error': 'Missing workspace_uuid'}), 400
+
+        allowed_modes = {'1': {'reference'}, '2': {'log'}}
+        metadata, error_response = validate_workspace_access(caseid, workspace_uuid, allowed_modes.get(mode))
+        if error_response:
+            return error_response
+
+        metadata_path = resolve_discovery_xes_path(metadata)
+        if not metadata_path or not os.path.exists(metadata_path):
+            return jsonify({'error': 'Unknown discovery id'}), 404
         
         # If rendering is ongoing, report status
         if render_status.get((view, caseid, activity, path)) == "rendering":
@@ -291,7 +302,7 @@ def viewer(view, caseid, mode=0):
             case _:
                 return "Unknown view"
             
-        thread = threading.Thread(target=run_viewer, args=(view, caseid, mode, activity, path, filtermode))
+        thread = threading.Thread(target=run_viewer, args=(view, caseid, mode, activity, path, filtermode, metadata_path))
         thread.start()
         return jsonify({'status': 'rendering started'}), 200
                     


### PR DESCRIPTION
### Motivation
- Enforce workspace ownership when listing or accessing discoveries so UI can request workspace-scoped lists and services only operate on authorized discoveries.
- Centralize discovery metadata access and XES path resolution to remove brittle direct `./imports2/<id>.xes` assumptions and enable consistent ownership checks.
- Provide clear HTTP error semantics (`404` for unknown discovery, `403` for forbidden workspace) across affected microservices.

### Description
- Added metadata access helpers to `metadata_store.py` (`get_discovery_metadata`, `list_discoveries`) returning records with `discovery_id`, `display_name`, `status`, and `created_at` and kept the existing DB schema initialization via `init_metadata_db`.
- Introduced a shared helper module `discovery_access.py` with `validate_workspace_access(discovery_id, workspace_uuid, allowed_modes=None)` and `resolve_discovery_xes_path(metadata)` to perform ownership validation and map `mode` → folder path.
- Reworked discovery listing and endpoints to require `workspace_uuid`: updated `listDiscovers.py` to expose a workspace-scoped `GET /?workspace_uuid=<uuid>&mode=<opt>` returning discovery objects and kept the legacy `/<mode>` endpoint as a deprecated, workspace-scoped id-only response.
- Updated services to validate ownership and use metadata-driven paths instead of direct file assumptions in `Discover_stats.py`, `basic_stats.py`, `CU_stats.py`, `Plan_stats.py`, `conformanceTest.py`, `alignement_viewer.py`, and `viewer_threaded.py`, and ensured endpoints return JSON `404`/`403` responses for unknown or unauthorized discoveries.

### Testing
- Ran Python byte-compile across modified modules with `python -m py_compile proyecto/PM_microservice/listDiscovers.py proyecto/PM_microservice/Discover_stats.py proyecto/PM_microservice/viewer_threaded.py proyecto/PM_microservice/conformanceTest.py proyecto/PM_microservice/alignement_viewer.py proyecto/PM_microservice/Plan_stats.py proyecto/PM_microservice/CU_stats.py proyecto/PM_microservice/basic_stats.py proyecto/PM_microservice/metadata_store.py proyecto/PM_microservice/discovery_access.py`, which completed successfully with no syntax errors.
- No additional automated integration tests were run in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4570e72f48332b815cab0030f4cef)