### PR TITLE
Add manual/workspace source selection to discover flows

### DIFF
--- a/proyecto/front/discover-reference.html
+++ b/proyecto/front/discover-reference.html
@@ -374,7 +374,24 @@
         <h2 data-lang="discoverReferenceDesc"></h2>
       </div>
         <label data-lang="referenceLog">Log de Referencia:</label>
-        <input id="file" name="file" type="file" accept=".csv" required/>
+
+        <div id="discoverSourceSelector" style="margin-bottom: 1rem;">
+          <label style="margin-right: 1rem;">
+            <input type="radio" name="discoverSource" value="manual_csv" checked>
+            manual_csv
+          </label>
+          <label>
+            <input type="radio" name="discoverSource" value="workspace_log">
+            workspace_log
+          </label>
+        </div>
+
+        <div id="fileInputWrapper">
+          <input id="file" name="file" type="file" accept=".csv" required/>
+        </div>
+
+        <label for="discoverName">Nombre (opcional):</label>
+        <input id="discoverName" name="discoverName" type="text" placeholder="Custom discovery name" />
 
         <div class="buttons-div">
             <button type="button" id="discoverLog" data-lang="discover">

--- a/proyecto/front/discover.html
+++ b/proyecto/front/discover.html
@@ -374,7 +374,24 @@
         <h2 data-lang="discoverDesc"></h2>
       </div>
         <label data-lang="studentLog">Log de Estudiantes:</label>
-        <input id="file" name="file" type="file" accept=".csv" required/>
+
+        <div id="discoverSourceSelector" style="margin-bottom: 1rem;">
+          <label style="margin-right: 1rem;">
+            <input type="radio" name="discoverSource" value="manual_csv" checked>
+            manual_csv
+          </label>
+          <label>
+            <input type="radio" name="discoverSource" value="workspace_log">
+            workspace_log
+          </label>
+        </div>
+
+        <div id="fileInputWrapper">
+          <input id="file" name="file" type="file" accept=".csv" required/>
+        </div>
+
+        <label for="discoverName">Nombre (opcional):</label>
+        <input id="discoverName" name="discoverName" type="text" placeholder="Custom discovery name" />
 
         <div class="buttons-div">
             <button type="button" id="discoverLog" data-lang="discover">

--- a/proyecto/front/js/discoverLog.js
+++ b/proyecto/front/js/discoverLog.js
@@ -19,32 +19,116 @@
 
 	Santiago Nicolás Díaz Conde Email: sndc.33@gmail.com and contact@fapret.com
 */
-function discover_log(mode = 0) {
-    const model_file = document.getElementById("file").files[0];
-    const loader = document.getElementById("loadingcontent");
-    loader.style.display = "flex";
 
-    var url = `http://127.0.0.1:9000/${mode}`;
-    var formData = new FormData();
-    formData.append('file', model_file);
+const EM_STUDENTS_LOG_URL = 'https://tmde-api.fapret.com:8443/curricula_microservice/GetStudentsLog';
 
-    // Configurar las opciones de la solicitud
-    var options = {
-        method: 'POST',
-        body: formData
+function getDiscoverSourceMode() {
+    const source = document.querySelector('input[name="discoverSource"]:checked');
+    return source ? source.value : 'manual_csv';
+}
 
+function setupDiscoverSourceSelector() {
+    const sourceRadios = document.querySelectorAll('input[name="discoverSource"]');
+    const fileInput = document.getElementById('file');
+    const fileInputWrapper = document.getElementById('fileInputWrapper');
+
+    const syncUI = () => {
+        const selectedMode = getDiscoverSourceMode();
+        const manualCSVMode = selectedMode === 'manual_csv';
+
+        fileInput.required = manualCSVMode;
+        fileInput.disabled = !manualCSVMode;
+        fileInputWrapper.style.display = manualCSVMode ? 'block' : 'none';
+        if (!manualCSVMode) {
+            fileInput.value = '';
+        }
     };
 
-    fetch(url, options)
+    sourceRadios.forEach((radio) => radio.addEventListener('change', syncUI));
+    syncUI();
+}
+
+async function fetchWorkspaceLogFile(workspaceUUID) {
+    const formData = new FormData();
+    formData.append('uuid', workspaceUUID);
+
+    const response = await fetch(EM_STUDENTS_LOG_URL, {
+        method: 'POST',
+        body: formData
+    });
+
+    if (!response.ok) {
+        throw new Error(`No se pudo obtener el log del workspace (${response.status})`);
+    }
+
+    const csvText = await response.text();
+    const blob = new Blob([csvText], { type: 'text/csv' });
+    return new File([blob], 'StudentsLog.csv', { type: 'text/csv' });
+}
+
+async function discover_log(mode = 0) {
+    const loader = document.getElementById('loadingcontent');
+    const resultadoDiv = document.getElementById('resultado');
+    const selectedMode = getDiscoverSourceMode();
+    const workspaceUUID = localStorage.getItem('selectedWorkspace');
+    const customName = document.getElementById('discoverName')?.value?.trim() || '';
+    const fileInput = document.getElementById('file');
+
+    let modelFile;
+
+    if (selectedMode === 'manual_csv') {
+        modelFile = fileInput.files[0];
+        if (!modelFile) {
+            alert('Debe seleccionar un archivo CSV (source: manual CSV).');
+            return;
+        }
+    } else {
+        if (!workspaceUUID) {
+            alert('Debe seleccionar un workspace (source: workspace log).');
+            return;
+        }
+        loader.style.display = 'flex';
+        try {
+            modelFile = await fetchWorkspaceLogFile(workspaceUUID);
+        } catch (error) {
+            loader.style.display = 'none';
+            console.error('Error al obtener log del workspace:', error);
+            resultadoDiv.style.display = 'block';
+            resultadoDiv.innerHTML = `Error al obtener el workspace log: ${error} (source: workspace log)`;
+            return;
+        }
+    }
+
+    loader.style.display = 'flex';
+
+    const url = `http://127.0.0.1:9000/${mode}`;
+    const formData = new FormData();
+    formData.append('file', modelFile);
+    formData.append('workspace_uuid', workspaceUUID || '');
+    formData.append('mode', selectedMode);
+    if (customName) {
+        formData.append('name', customName);
+    }
+
+    fetch(url, {
+        method: 'POST',
+        body: formData
+    })
         .then(response => response.json())
         .then(data => {
-            loader.style.display = "none";
-            alert("Descubierto con id: " + data.uuid);
+            loader.style.display = 'none';
+            const sourceLabel = selectedMode === 'manual_csv' ? 'source: manual CSV' : 'source: workspace log';
+            resultadoDiv.style.display = 'block';
+            resultadoDiv.innerHTML = `Descubierto con id: ${data.uuid} (${sourceLabel})`;
+            alert(`Descubierto con id: ${data.uuid} (${sourceLabel})`);
         })
         .catch(error => {
-            console.error("Error al consultar la API:", error);
-            const resultadoDiv = document.getElementById("resultado");
-            resultadoDiv.style.display = "block";
-            resultadoDiv.innerHTML = "Error al consultar la API: "+error;
+            loader.style.display = 'none';
+            console.error('Error al consultar la API:', error);
+            resultadoDiv.style.display = 'block';
+            const sourceLabel = selectedMode === 'manual_csv' ? 'source: manual CSV' : 'source: workspace log';
+            resultadoDiv.innerHTML = `Error al consultar la API: ${error} (${sourceLabel})`;
         });
 }
+
+window.addEventListener('DOMContentLoaded', setupDiscoverSourceSelector);

--- a/proyecto/front/js/discoverLogExec.js
+++ b/proyecto/front/js/discoverLogExec.js
@@ -19,8 +19,9 @@
 
 	Santiago Nicolás Díaz Conde Email: sndc.33@gmail.com and contact@fapret.com
 */
-const discoverLogBtn = document.getElementById("discoverLog");
+const discoverLogBtn = document.getElementById('discoverLog');
 
-discoverLogBtn.addEventListener("click", (event) => {
-    discover_log();
+discoverLogBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    discover_log(0);
 });

--- a/proyecto/front/js/discoverLogExec2.js
+++ b/proyecto/front/js/discoverLogExec2.js
@@ -19,8 +19,9 @@
 
 	Santiago Nicolás Díaz Conde Email: sndc.33@gmail.com and contact@fapret.com
 */
-const discoverLogBtn = document.getElementById("discoverLog");
+const discoverLogBtn = document.getElementById('discoverLog');
 
-discoverLogBtn.addEventListener("click", (event) => {
+discoverLogBtn.addEventListener('click', (event) => {
+    event.preventDefault();
     discover_log(1);
 });


### PR DESCRIPTION
### Motivation
- Provide a choice between uploading a `manual_csv` and using a `workspace_log` as the discovery input so users can run discovery from an EM workspace without downloading/uploading files manually.  
- Allow an optional custom discovery `name` to be supplied and propagate metadata (`workspace_uuid`, `mode`, `name`) to the PM discovery endpoint.  
- Keep existing manual CSV behavior unchanged while hiding/disabling the file picker when `workspace_log` is selected and require a workspace selection instead.  
- Make UX messages explicit about the CSV source ("source: manual CSV" vs "source: workspace log").

### Description
- Added a radio source selector (`manual_csv` default / `workspace_log`) and an optional `discoverName` input to `proyecto/front/discover.html` and `proyecto/front/discover-reference.html`.  
- Implemented `getDiscoverSourceMode` and `setupDiscoverSourceSelector` in `proyecto/front/js/discoverLog.js` to toggle the file input `required`/`disabled` state and show/hide the file picker; added a DOM-ready hook to initialize the selector.  
- Added `fetchWorkspaceLogFile` to `discoverLog.js` which POSTs to the EM `GetStudentsLog` endpoint, creates a `Blob`/`File` from the returned CSV, and updated `discover_log` to submit multipart form data including `file`, `workspace_uuid`, `mode`, and optional `name` to the PM endpoint.  
- Updated `proyecto/front/js/discoverLogExec.js` and `proyecto/front/js/discoverLogExec2.js` to `preventDefault()` and call `discover_log(0)` / `discover_log(1)` respectively, and adjusted success/error messages to include explicit source labels.

### Testing
- Ran repository inspections and diffs (`rg`, `git diff`) to verify the updated files `proyecto/front/discover.html`, `proyecto/front/discover-reference.html`, `proyecto/front/js/discoverLog.js`, `proyecto/front/js/discoverLogExec.js`, and `proyecto/front/js/discoverLogExec2.js`, and the commands completed successfully.  
- Committed changes to the branch and checked repository status (`git commit`, `git status`), and the commit succeeded with no leftover changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4592d51088332acb20367cf8becb3)