### PR TITLE
Add protected workspace unlock flow and token-based auth with retry

### DIFF
--- a/proyecto/front/js/workspaceSelector.js
+++ b/proyecto/front/js/workspaceSelector.js
@@ -19,6 +19,10 @@
 
     Santiago Nicolás Díaz Conde Email: sndc.33@gmail.com and contact@fapret.com
 */
+const WORKSPACES_BASE_URL = 'https://tmde-api.fapret.com:8443/curricula_microservice/Workspaces';
+const API_BASE_PREFIX = 'https://tmde-api.fapret.com:8443/curricula_microservice/';
+const WORKSPACE_TOKEN_STORAGE_PREFIX = 'workspaceToken:';
+
 const selector = document.getElementById('workspaceSelector');
 const choices = new Choices(selector, {
     searchPlaceholderValue: 'Search workspaces...',
@@ -26,28 +30,209 @@ const choices = new Choices(selector, {
     removeItemButton: false,
 });
 
+let cachedWorkspaces = [];
+
+function getWorkspaceToken(uuid) {
+    if (!uuid) return null;
+    return sessionStorage.getItem(`${WORKSPACE_TOKEN_STORAGE_PREFIX}${uuid}`);
+}
+
+function setWorkspaceToken(uuid, token) {
+    if (!uuid) return;
+    const key = `${WORKSPACE_TOKEN_STORAGE_PREFIX}${uuid}`;
+    if (token) {
+        sessionStorage.setItem(key, token);
+    } else {
+        sessionStorage.removeItem(key);
+    }
+}
+
+function normalizeWorkspace(workspaceEntry) {
+    if (typeof workspaceEntry === 'string') {
+        return { uuid: workspaceEntry, protected: false };
+    }
+    return {
+        uuid: workspaceEntry.uuid,
+        protected: Boolean(workspaceEntry.protected)
+    };
+}
+
+async function unlockWorkspace(uuid, promptMessage = `Workspace ${uuid} is protected. Enter password:`) {
+    const password = prompt(promptMessage);
+    if (!password) {
+        return false;
+    }
+
+    const formData = new FormData();
+    formData.append('uuid', uuid);
+    formData.append('password', password);
+
+    const response = await fetch(`${WORKSPACES_BASE_URL}/Unlock`, {
+        method: 'POST',
+        body: formData,
+        skipWorkspaceAuthRetry: true,
+    });
+
+    if (!response.ok) {
+        throw new Error('Invalid workspace password');
+    }
+
+    let token = null;
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+        const payload = await response.json();
+        token = payload?.token || payload?.workspaceToken || payload?.accessToken || null;
+    } else {
+        token = (await response.text()).trim();
+    }
+
+    if (!token) {
+        throw new Error('Unlock endpoint returned no token');
+    }
+
+    setWorkspaceToken(uuid, token);
+    return true;
+}
+
+function shouldAttachWorkspaceAuth(requestUrl) {
+    return requestUrl.startsWith(API_BASE_PREFIX)
+        && !requestUrl.includes('/Workspaces')
+        && !requestUrl.includes('/Workspaces/Unlock');
+}
+
+function installWorkspaceAuthFetchInterceptor() {
+    if (window.__workspaceAuthFetchInstalled) {
+        return;
+    }
+
+    window.__workspaceAuthFetchInstalled = true;
+    const originalFetch = window.fetch.bind(window);
+
+    window.fetch = async (input, init = {}) => {
+        const requestUrl = typeof input === 'string' ? input : input.url;
+        if (!shouldAttachWorkspaceAuth(requestUrl)) {
+            return originalFetch(input, init);
+        }
+
+        const selectedWorkspace = localStorage.getItem('selectedWorkspace');
+        const token = getWorkspaceToken(selectedWorkspace);
+        const headers = new Headers(init.headers || (input instanceof Request ? input.headers : undefined));
+
+        if (token) {
+            headers.set('Authorization', `Bearer ${token}`);
+        }
+
+        const requestInit = { ...init, headers };
+        let response = await originalFetch(input, requestInit);
+
+        if (
+            response.status === 401
+            && !requestInit._workspaceAuthRetried
+            && !requestInit.skipWorkspaceAuthRetry
+            && selectedWorkspace
+        ) {
+            const workspace = cachedWorkspaces.find(item => item.uuid === selectedWorkspace);
+            if (workspace?.protected) {
+                const unlocked = await unlockWorkspace(selectedWorkspace, `Session expired for protected workspace ${selectedWorkspace}. Enter password:`);
+                if (unlocked) {
+                    const retryToken = getWorkspaceToken(selectedWorkspace);
+                    if (retryToken) {
+                        headers.set('Authorization', `Bearer ${retryToken}`);
+                    }
+                    response = await originalFetch(input, { ...requestInit, headers, _workspaceAuthRetried: true });
+                }
+            }
+        }
+
+        return response;
+    };
+}
+
+function installWorkspaceAuthXHRInterceptor() {
+    if (window.__workspaceAuthXHRInstalled) {
+        return;
+    }
+
+    window.__workspaceAuthXHRInstalled = true;
+
+    const originalOpen = XMLHttpRequest.prototype.open;
+    const originalSend = XMLHttpRequest.prototype.send;
+
+    XMLHttpRequest.prototype.open = function (method, url, async, user, password) {
+        this.__workspaceAuthUrl = url;
+        this.__workspaceAuthMethod = method;
+        this.__workspaceAuthRetried = false;
+        return originalOpen.call(this, method, url, async, user, password);
+    };
+
+    XMLHttpRequest.prototype.send = function (body) {
+        const url = this.__workspaceAuthUrl;
+        if (!url || !shouldAttachWorkspaceAuth(url)) {
+            return originalSend.call(this, body);
+        }
+
+        const workspaceId = localStorage.getItem('selectedWorkspace');
+        const token = getWorkspaceToken(workspaceId);
+        if (token) {
+            this.setRequestHeader('Authorization', `Bearer ${token}`);
+        }
+
+        this.addEventListener('load', async () => {
+            if (this.status !== 401 || this.__workspaceAuthRetried || !workspaceId) {
+                return;
+            }
+
+            const workspace = cachedWorkspaces.find(item => item.uuid === workspaceId);
+            if (!workspace?.protected) {
+                return;
+            }
+
+            try {
+                const unlocked = await unlockWorkspace(workspaceId, `Session expired for protected workspace ${workspaceId}. Enter password:`);
+                if (!unlocked) {
+                    return;
+                }
+
+                const retryToken = getWorkspaceToken(workspaceId);
+                if (!retryToken) {
+                    return;
+                }
+
+                this.__workspaceAuthRetried = true;
+                this.open(this.__workspaceAuthMethod || 'GET', url, true);
+                this.setRequestHeader('Authorization', `Bearer ${retryToken}`);
+                this.send(body);
+            } catch (error) {
+                console.error('Workspace unlock failed after 401:', error);
+            }
+        });
+
+        return originalSend.call(this, body);
+    };
+}
+
 async function loadWorkspaces() {
     try {
-        //const response = await fetch('http://localhost:8080/curricula_microservice/Workspaces');
-        const response = await fetch('https://tmde-api.fapret.com:8443/curricula_microservice/Workspaces');
+        const response = await fetch(WORKSPACES_BASE_URL, { skipWorkspaceAuthRetry: true });
         if (!response.ok) throw new Error('Failed to fetch workspaces');
-        const workspaces = await response.json(); // ["uuid1", "uuid2", ...]
 
-        // Clear and add options
+        const rawWorkspaces = await response.json();
+        cachedWorkspaces = rawWorkspaces.map(normalizeWorkspace);
+        const workspaceUUIDs = cachedWorkspaces.map(workspace => workspace.uuid);
+
         choices.clearChoices();
         choices.setChoices(
             [
                 { value: '__create__', label: '➕ Create new workspace', customProperties: { isCreateOption: true } },
-                ...workspaces.map(uuid => ({ value: uuid, label: uuid }))
+                ...workspaceUUIDs.map(uuid => ({ value: uuid, label: uuid }))
             ],
             'value',
             'label',
             true
         );
 
-        // Restore previous selection
         const savedUUID = localStorage.getItem('selectedWorkspace');
-        if (savedUUID && workspaces.includes(savedUUID)) {
+        if (savedUUID && workspaceUUIDs.includes(savedUUID)) {
             choices.setChoiceByValue(savedUUID);
             setSelectedLabel(savedUUID);
         }
@@ -57,12 +242,10 @@ async function loadWorkspaces() {
     }
 }
 
-// Update the visible selected label
 function setSelectedLabel(uuid) {
     const selectedItem = selector.closest('.choices').querySelector('.choices__item--selectable');
     if (selectedItem) {
         selectedItem.innerHTML = `Workspace: <span class="workspace-label">${uuid}</span>`;
-        //selectedItem.textContent = `Workspace: ${uuid}`;
     }
 }
 
@@ -72,7 +255,6 @@ selector.addEventListener('change', async (e) => {
     if (value === '__create__') {
         const uuid = prompt('Enter new workspace UUID:');
         if (!uuid) {
-            // Revert to previous selection if canceled
             const saved = localStorage.getItem('selectedWorkspace');
             if (saved) choices.setChoiceByValue(saved);
             return;
@@ -82,10 +264,10 @@ selector.addEventListener('change', async (e) => {
             const formData = new FormData();
             formData.append('uuid', uuid);
 
-            //const response = await fetch('http://localhost:8080/curricula_microservice/Workspaces', {
-            const response = await fetch('https://tmde-api.fapret.com:8443/curricula_microservice/Workspaces', {
+            const response = await fetch(WORKSPACES_BASE_URL, {
                 method: 'POST',
-                body: formData
+                body: formData,
+                skipWorkspaceAuthRetry: true,
             });
 
             if (!response.ok) throw new Error('Failed to create workspace');
@@ -100,11 +282,32 @@ selector.addEventListener('change', async (e) => {
             alert('Error creating workspace');
         }
     } else {
-        localStorage.setItem('selectedWorkspace', value);
-        setSelectedLabel(value);
-        console.log('Selected workspace:', value);
+        try {
+            const selectedWorkspace = cachedWorkspaces.find(workspace => workspace.uuid === value);
+            if (selectedWorkspace?.protected) {
+                const unlocked = await unlockWorkspace(value);
+                if (!unlocked) {
+                    const saved = localStorage.getItem('selectedWorkspace');
+                    if (saved) choices.setChoiceByValue(saved);
+                    return;
+                }
+            }
+
+            localStorage.setItem('selectedWorkspace', value);
+            setSelectedLabel(value);
+            console.log('Selected workspace:', value);
+        } catch (error) {
+            console.error(error);
+            alert('Unable to unlock workspace');
+            const saved = localStorage.getItem('selectedWorkspace');
+            if (saved) {
+                choices.setChoiceByValue(saved);
+                setSelectedLabel(saved);
+            }
+        }
     }
 });
 
-// Initial load
+installWorkspaceAuthFetchInterceptor();
+installWorkspaceAuthXHRInterceptor();
 loadWorkspaces();


### PR DESCRIPTION
### Motivation
- Support workspaces that are marked as protected so the front-end can request a password and receive an access token before calling EM/Curricula APIs.
- Ensure all front-end calls to the Curricula API include the workspace token in the `Authorization` header to enforce workspace-level access.
- Keep existing behavior unchanged for unprotected workspaces while improving security by using `sessionStorage` per-workspace tokens.

### Description
- Normalize `GET /Workspaces` results to accept either plain UUID strings (legacy) or `{ uuid, protected }` entries so protected metadata is available without breaking older responses.
- Implement `unlockWorkspace(uuid)` which prompts for a password, calls `POST /Workspaces/Unlock`, extracts a token from JSON or text responses, and stores it keyed by `workspaceToken:<uuid>` in `sessionStorage`.
- Add a global `fetch` interceptor that attaches `Authorization: Bearer <token>` for API calls under the Curricula prefix and, on `401`, re-prompts for password and retries once for protected workspaces.
- Add an `XMLHttpRequest` interceptor so existing XHR-based modules also receive the `Authorization` header and get a single retry after unlock; leave unprotected flows untouched.

### Testing
- Ran a static syntax check with `node --check proyecto/front/js/workspaceSelector.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d45b54c18c8332813875bccb87e1e1)