### PR TITLE
Include selected workspace in getDiscoveries requests

### DIFF
--- a/proyecto/front/js/selectLib.js
+++ b/proyecto/front/js/selectLib.js
@@ -221,7 +221,12 @@ function getMaterias(select, faculty, career, plan){
 }
 
 function getDiscoveries(select, mode = 0){
-  const url = `http://127.0.0.1:9004/${mode}`;
+  const workspaceID = localStorage.getItem('selectedWorkspace');
+  if (workspaceID == null || workspaceID === "") {
+    alert("Please select a workspace");
+    return;
+  }
+  const url = `http://127.0.0.1:9004/${mode}?workspace_uuid=${encodeURIComponent(workspaceID)}`;
   fetch(url)
   .then(response => response.json())
   .then(data => {


### PR DESCRIPTION
### Motivation
- Ensure discovery/PM requests are scoped to the currently selected workspace so pages that use `getDiscoveries(...)` (stats, diagrams, conformance, compare, etc.) receive and operate on the correct workspace data.

### Description
- Updated `getDiscoveries(select, mode = 0)` in `proyecto/front/js/selectLib.js` to read `selectedWorkspace` from `localStorage`, alert and return early when it is missing or empty, and append `?workspace_uuid=${encodeURIComponent(workspaceID)}` to the request URL while keeping existing response handling that fills the target `<select>`.

### Testing
- Ran a usage search for `getDiscoveries(` with `rg` to confirm all front-end call sites use the shared helper and will now include `workspace_uuid`, and the search completed successfully.
- Inspected the updated function in `proyecto/front/js/selectLib.js` with a file listing to verify the new guard and query-parameter were applied correctly and the file shows the intended changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d48eb11a7c83328d87ee691ee49ccf)