### PR TITLE
Add buildPMWorkspaceUrl helper and include workspace_uuid in PM endpoints

### DIFF
--- a/proyecto/front/js/compareTimes.js
+++ b/proyecto/front/js/compareTimes.js
@@ -27,7 +27,7 @@ function compareDiscovers() {
 
     const resultadoDiv = document.getElementById("resultado");
 
-    const url = `http://127.0.0.1:9005/${uuidA}/${uuidB}`;
+    const url = buildPMWorkspaceUrl(`http://127.0.0.1:9005/${uuidA}/${uuidB}`);
     fetch(url)
     .then(response => response.text())
     .then(text => {

--- a/proyecto/front/js/conformance.js
+++ b/proyecto/front/js/conformance.js
@@ -24,7 +24,7 @@ function seeConformance(mode) {
     const allReferencesSelect = document.getElementById("references");
     const uuid = allDiscoveriesSelect.value;
     const refuuid = allReferencesSelect.value;
-    const url = `http://127.0.0.1:9007/${mode}/${refuuid}/${uuid}`;
+    const url = buildPMWorkspaceUrl(`http://127.0.0.1:9007/${mode}/${refuuid}/${uuid}`);
     fetch(url)
     .then(response => response.json())
     .then(data => {

--- a/proyecto/front/js/getPlanStats.js
+++ b/proyecto/front/js/getPlanStats.js
@@ -26,7 +26,7 @@ function displayPlanStats(){
     const plan = allPlansSelect.value;
     const allCareersSelect = document.getElementById("carreras");
     const career = allCareersSelect.value;
-    const url = `http://127.0.0.1:9006/${uuid}/${career}/${plan}`;
+    const url = buildPMWorkspaceUrl(`http://127.0.0.1:9006/${uuid}/${career}/${plan}`);
     fetch(url)
     .then(response => response.json())
     .then(data => {

--- a/proyecto/front/js/getUCStats.js
+++ b/proyecto/front/js/getUCStats.js
@@ -26,7 +26,7 @@ function displayUCStats(){
     const uc = allUCSelect.value;
     const allDiscoveriesSelect = document.getElementById("discoveries");
     const uuid = allDiscoveriesSelect.value;
-    const url = `http://127.0.0.1:9003/${uuid}/${uc}`;
+    const url = buildPMWorkspaceUrl(`http://127.0.0.1:9003/${uuid}/${uc}`);
     fetch(url)
     .then(response => response.json())
     .then(data => {

--- a/proyecto/front/js/seeAlignDiagram.js
+++ b/proyecto/front/js/seeAlignDiagram.js
@@ -40,7 +40,7 @@ function seeDiagram(mode) {
         default:
             return;
     }
-    const url = `http://127.0.0.1:9008/${modestr}/${refuuid}/${uuid}`;
+    const url = buildPMWorkspaceUrl(`http://127.0.0.1:9008/${modestr}/${refuuid}/${uuid}`);
     img.src = url;
     img.classList.remove('hidden');
     diagramsButtons.classList.remove('hidden');

--- a/proyecto/front/js/seeDiagrams.js
+++ b/proyecto/front/js/seeDiagrams.js
@@ -50,7 +50,7 @@ function seeDiagram(mode, type=0, activity=100, paths=100) {
         default:
             return;
     }
-    const url = `http://127.0.0.1:9001/${modestr}/${uuid}/${type}?activity=${activity}&path=${paths}`;
+    const url = buildPMWorkspaceUrl(`http://127.0.0.1:9001/${modestr}/${uuid}/${type}?activity=${activity}&path=${paths}`);
     img.src = url;
     img.classList.remove('hidden');
     diagramsButtons.classList.remove('hidden');

--- a/proyecto/front/js/seeDiscoverStats.js
+++ b/proyecto/front/js/seeDiscoverStats.js
@@ -22,7 +22,7 @@
 function seeDiscoverStats(mode=2) {
     const allDiscoveriesSelect = document.getElementById("discoveries");
     const uuid = allDiscoveriesSelect.value;
-    const url = `http://127.0.0.1:9002/${uuid}/${mode}`;
+    const url = buildPMWorkspaceUrl(`http://127.0.0.1:9002/${uuid}/${mode}`);
     fetch(url)
     .then(response => response.json())
     .then(data => {

--- a/proyecto/front/js/selectLib.js
+++ b/proyecto/front/js/selectLib.js
@@ -22,6 +22,17 @@
 */
 const fetchCacheUC = new Map();
 
+
+function buildPMWorkspaceUrl(baseUrl) {
+  const workspaceID = localStorage.getItem('selectedWorkspace');
+  if (workspaceID == null) {
+    alert("Please select a workspace");
+    throw new Error("selectedWorkspace missing in localStorage");
+  }
+  const separator = baseUrl.includes('?') ? '&' : '?';
+  return `${baseUrl}${separator}workspace_uuid=${encodeURIComponent(workspaceID)}`;
+}
+
 function addToSelect(select, idelement){
   let option = document.createElement('option');
   option.setAttribute('value', idelement);


### PR DESCRIPTION
### Motivation
- PM microservice requests used by frontend stats and diagram views must be scoped to the currently selected workspace so responses are correct for that workspace.

### Description
- Added `buildPMWorkspaceUrl(baseUrl)` in `proyecto/front/js/selectLib.js` which reads `selectedWorkspace` from `localStorage`, alerts/throws if missing, and appends `workspace_uuid` using `?` or `&` as appropriate.
- Replaced hardcoded PM URLs with `buildPMWorkspaceUrl(...)` in the files `seeDiscoverStats.js`, `getUCStats.js`, `getPlanStats.js`, `seeDiagrams.js`, `compareTimes.js`, `conformance.js`, and `seeAlignDiagram.js` so path parameters are preserved and the workspace query parameter is always added.
- Updated diagram image endpoints (assigned to `img.src`) to use the helper so image requests also include `workspace_uuid`.

### Testing
- Ran syntax checks with Node for the updated files using `node --check` on `proyecto/front/js/selectLib.js`, `seeDiscoverStats.js`, `getUCStats.js`, `getPlanStats.js`, `seeDiagrams.js`, `compareTimes.js`, `conformance.js`, and `seeAlignDiagram.js`, and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d496f06c688332b4ff527dd4a3c021)