### PR TITLE
Add Docker Compose and Dockerfiles for Tomcat and PM services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  curricula:
+    build:
+      context: .
+      dockerfile: docker/tomcat/Dockerfile
+    ports:
+      - "8080:8080"
+    container_name: trajecta-curricula
+
+  pm:
+    build:
+      context: .
+      dockerfile: docker/pm/Dockerfile
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+      - "9002:9002"
+      - "9003:9003"
+      - "9004:9004"
+      - "9005:9005"
+      - "9006:9006"
+      - "9007:9007"
+      - "9008:9008"
+      - "9009:9009"
+    volumes:
+      - pm-data:/app
+    container_name: trajecta-pm
+
+volumes:
+  pm-data:

--- a/docker/pm/Dockerfile
+++ b/docker/pm/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends graphviz \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY proyecto/PM_microservice/ /app/
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 9000 9001 9002 9003 9004 9005 9006 9007 9008 9009
+
+CMD ["sh", "-c", "python start_scripts.py && tail -f /dev/null"]

--- a/docker/tomcat/Dockerfile
+++ b/docker/tomcat/Dockerfile
@@ -1,0 +1,7 @@
+FROM tomcat:10.1-jdk17-temurin
+
+RUN rm -rf /usr/local/tomcat/webapps/*
+
+COPY proyecto/java_microservice/dist/curricula_microservice.war /usr/local/tomcat/webapps/ROOT.war
+
+EXPOSE 8080

--- a/proyecto/PM_microservice/requirements.txt
+++ b/proyecto/PM_microservice/requirements.txt
@@ -1,0 +1,4 @@
+pm4py
+flask
+flask_cors
+pandas


### PR DESCRIPTION
### Motivation

- Proveer una forma reproducible de ejecutar el microservicio Java (Tomcat) y el microservicio PM (Python) localmente usando Docker Compose.
- Simplificar el despliegue con puertos expuestos y un volumen persistente para datos de PM.

### Description

- Agrega `docker-compose.yml` en la raíz definiendo los servicios `curricula` y `pm` con los mapeos de puertos y el volumen `pm-data`.
- Agrega `docker/tomcat/Dockerfile` basado en `tomcat:10.1-jdk17-temurin` que limpia `webapps` y copia `proyecto/java_microservice/dist/curricula_microservice.war` como `ROOT.war`, y expone el puerto `8080`.
- Agrega `docker/pm/Dockerfile` basado en `python:3.11-slim` que instala `graphviz`, copia `proyecto/PM_microservice/`, instala dependencias desde `requirements.txt`, expone `9000-9009` y ejecuta `start_scripts.py`.
- Agrega `proyecto/PM_microservice/requirements.txt` con `pm4py`, `flask`, `flask_cors` y `pandas`, y todos los archivos fueron añadidos y commiteados.

### Testing

- Intenté `docker compose config` pero falló porque `docker` no está instalado en este entorno.
- Ejecuté `test -f proyecto/java_microservice/dist/curricula_microservice.war` y el WAR resultó ausente, por lo que debe generarse antes de ejecutar `docker compose up --build`.
- Verifiqué el target Ant `build-war` que genera `dist/curricula_microservice.war` con `rg -n "name=\"build-war\"|curricula_microservice\.war" proyecto/java_microservice/build.xml` y la comprobación fue exitosa.
- No se realizaron builds de contenedores ni pruebas de integración en este entorno debido a las limitaciones de Docker aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dab8a47208332923a1845a250309f)